### PR TITLE
Fix possible AttributeError

### DIFF
--- a/robobrowser/forms/form.py
+++ b/robobrowser/forms/form.py
@@ -25,7 +25,7 @@ def _group_flat_tags(tag, tags):
     """
     grouped = [tag]
     name = tag.get('name').lower()
-    while tags and tags[0].get('name').lower() == name:
+    while tags and tags[0].get('name') and tags[0].get('name').lower() == name:
         grouped.append(tags.pop(0))
     return grouped
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -63,6 +63,18 @@ mock_forms = mock_responses(
             '''
         ),
         ArgCatcher(
+            responses.GET, 'http://robobrowser.com/noname/',
+            body=b'''
+                <form name="input" action="action" method="get">
+                <input type="checkbox" name="vehicle" value="Bike">
+                    I have a bike<br>
+                <input type="checkbox" name="vehicle" value="Car">I have a car
+                <br><br>
+                <input type="submit" value="Submit">
+                </form>
+            '''
+        ),
+        ArgCatcher(
             responses.POST, 'http://robobrowser.com/post/',
         ),
     ]
@@ -161,6 +173,18 @@ class TestForms(unittest.TestCase):
         form = self.browser.get_form()
         self.browser.submit_form(form)
         assert_equal(self.browser.url, 'http://robobrowser.com/post/')
+
+class TestFormsInputNoName(unittest.TestCase):
+
+    @mock_forms
+    def setUp(self):
+        self.browser = RoboBrowser()
+        self.browser.open('http://robobrowser.com/noname/')
+
+    @mock_forms
+    def test_get_forms(self):
+        forms = self.browser.get_forms()
+        assert_equal(len(forms), 1)
 
 class TestHistoryInternals(unittest.TestCase):
 


### PR DESCRIPTION
I came across this problem when I called get_forms() on a page with a form that contains checkboxes. I got this error:
AttributeError: "'NoneType' object has no attribute 'lower'"
on this line:
while tags and tags[0].get('name').lower() == name:
One of the inputs didn't have a 'name' attributed and it caused this error.
I added a check to ensure that get('name') does return a valid object before calling lower() on it, and also a test case for this problem.
- Fix AttributeError that occures when searching for inputs with the same
  name, and of the inputs doesn't have 'name' attribute. We need to check
  if the object exists before calling lower().
- Add mock response and test for form where there are checkboxes with the
  same name and one input with no name
