### PR TITLE
Fixed Python 3 compatibility issue (dict.iteritems didn't exist)

### DIFF
--- a/robobrowser/forms/form.py
+++ b/robobrowser/forms/form.py
@@ -5,7 +5,7 @@ HTML forms.
 import re
 import collections
 
-from robobrowser.compat import OrderedDict
+from robobrowser.compat import OrderedDict, iteritems
 
 from . import fields
 from .. import helpers
@@ -141,7 +141,7 @@ class Form(object):
         state = ', '.join(
             [
                 '{0}={1}'.format(name, field.value)
-                for name, field in self.fields.iteritems()
+                for name, field in iteritems(self.fields)
             ]
         )
         if state:


### PR DESCRIPTION
I had a problem with Form.**repr** using Python 3.3; it seems that OrderedDict.iteritems doesn't exist. This minor change made it work for me.
