### PR TITLE
fix issue with building bad POST requests

### DIFF
--- a/robobrowser/browser.py
+++ b/robobrowser/browser.py
@@ -337,7 +337,7 @@ class RoboBrowser(object):
         # Send request
         url = self._build_url(form.action) or self.url
         form_data = form.serialize()
-        response = self.session.request(method, url, **form_data.to_requests())
+        response = self.session.request(method, url, **form_data.to_requests(method))
 
         # Update history
         self._update_state(response)


### PR DESCRIPTION
Using submit_form doesn't properly notify requests which method is being used, resulting in POST data being sent as params instead.
