### PR TITLE
Updated requirements for pip 6.0+ to include a session

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@
 # -*- coding: utf-8 -*-
 
 import os
-import re, uuid
+import re
 import sys
+import pip
 
 from setuptools import setup, find_packages
 from pip.req import parse_requirements
@@ -35,7 +36,7 @@ readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 requirements = [
     str(requirement.req)
-    for requirement in parse_requirements('requirements.txt', session=uuid.uuid1())
+    for requirement in parse_requirements('requirements.txt', session=pip.download.PipSession())
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
-import re
+import re, uuid
 import sys
 
 from setuptools import setup, find_packages
@@ -35,7 +35,7 @@ readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 requirements = [
     str(requirement.req)
-    for requirement in parse_requirements('requirements.txt')
+    for requirement in parse_requirements('requirements.txt', session=uuid.uuid1())
 ]
 
 setup(


### PR DESCRIPTION
Installing robobrowser with pip 6.0+ was failing due to:
TypeError: parse_requirements() missing 1 required keyword argument: 'session'

Fixed setup.py to include a session.