### PR TITLE
Switched requirements from == to >=.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.3.2
-requests==2.3.0
-six==1.7.3
-werkzeug==0.9.6
+beautifulsoup4>=4.3.2
+requests>=2.3.0
+six>=1.7.3
+werkzeug>=0.9.6


### PR DESCRIPTION
This hard version requirements can cause a lot of woes in ArchLinux packaging.
Would you please consider the change to allow greater versions of the dependencies?
Thank you!