### PR TITLE
Fixed: Parsing of empty select boxes failed

### DIFF
--- a/robobrowser/forms/fields.py
+++ b/robobrowser/forms/fields.py
@@ -41,7 +41,7 @@ class BaseField(object):
 
     """
     def __init__(self, parsed):
-        self._parsed = helpers.ensure_soup(parsed)
+        self._parsed = helpers.ensure_soup(parsed, use_builtin_parser=True)
         self._value = None
         self.name = self._get_name(self._parsed)
 

--- a/robobrowser/forms/fields.py
+++ b/robobrowser/forms/fields.py
@@ -240,7 +240,7 @@ class Select(NestedOptionField, MultiOptionField):
 
         """
         super(Select, self)._set_initial(initial)
-        if not self._value:
+        if not self._value and self.options:
             self.value = self.options[0]
 
 

--- a/robobrowser/helpers.py
+++ b/robobrowser/helpers.py
@@ -57,10 +57,11 @@ def find(soup, name=None, attrs=None, recursive=True, text=None, **kwargs):
         return tags[0]
 
 
-def ensure_soup(value):
+def ensure_soup(value, use_builtin_parser=False):
     """Coerce a value (or list of values) to Tag (or list of Tag).
 
     :param value: String, BeautifulSoup, Tag, or list of the above
+    :param use_builtin_parser: Boolean - if True, then force uses builtin parser instead of lxml
     :return: Tag or list of Tags
 
     """
@@ -70,10 +71,13 @@ def ensure_soup(value):
         return value
     if isinstance(value, list):
         return [
-            ensure_soup(item)
+            ensure_soup(item, use_builtin_parser)
             for item in value
         ]
-    parsed = BeautifulSoup(value)
+    if use_builtin_parser:
+        parsed = BeautifulSoup(value, 'html.parser')
+    else:
+        parsed = BeautifulSoup(value)
     return parsed.find()
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 import os
 import re
 import sys
+import pip
 
 from setuptools import setup, find_packages
 from pip.req import parse_requirements
@@ -35,7 +36,7 @@ readme = open('README.rst').read()
 history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 requirements = [
     str(requirement.req)
-    for requirement in parse_requirements('requirements.txt')
+    for requirement in parse_requirements('requirements.txt', session=pip.download.PipSession())
 ]
 
 setup(

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -625,7 +625,7 @@ class TestDefaultValues(unittest.TestCase):
             <select name="select">
                 <option>opt</option>
             </select>
-        ''')
+        ''', 'html.parser')
         select = fields.Select(parsed)
         assert_equal(select.options, ['sel'])
 
@@ -634,6 +634,6 @@ class TestDefaultValues(unittest.TestCase):
             <select name="select" multiple>
                 <option>opt</option>
             </select>
-        ''')
+        ''', 'html.parser')
         select = fields.Select(parsed)
         assert_equal(select.options, ['sel'])

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -218,6 +218,16 @@ class TestParser(unittest.TestCase):
         assert_equal(len(_fields), 1)
         assert_true(isinstance(_fields[0], fields.Select))
 
+    def test_parse_empty_select(self):
+        html = '''
+            <select name="instrument"></select>
+        '''
+        _fields = _parse_fields(BeautifulSoup(html))
+        assert_equal(len(_fields), 1)
+        assert_true(isinstance(_fields[0], fields.Select))
+        assert_equal(_fields[0].value, '')
+        assert_equal(_fields[0].options, [])
+
     def test_parse_select_multi(self):
         html = '''
             <select name="instrument" multiple>


### PR DESCRIPTION
Hi Joshua,

RoboBrowser failed to parse forms where there were empty select boxes. I have added the tests as well as the fix for the same.

The use cases of empty select boxes are pretty common on ASP website where forms require multiple submits. Before the initial submit the select boxes are kept empty. On initial submit, the select boxes get a few options based on other values.

Do let me know if anything is required to be modified in the pull request.
Pratyush