### PR TITLE
Add error message for selecting non-existent option in multi-option field

### DIFF
--- a/robobrowser/forms/fields.py
+++ b/robobrowser/forms/fields.py
@@ -125,7 +125,8 @@ class MultiOptionField(BaseField):
             index = self.labels.index(value)
             if index not in self.labels[index:]:
                 return index
-        raise ValueError
+        raise ValueError('Option "{o}" does not exist in multi-option form '
+                         'field "{f}".'.format(o=value, f=self.name))
 
     # Property methods
     def _get_value(self):


### PR DESCRIPTION
This fixes #8 by adding an error message that references the field and the non-existent option being selected. I did not list some of the valid options as it seemed to make for an overly lengthy error message, but they would be easy to add in.