### PR TITLE
Update to README to fix Beautiful Soup Error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ that don't have APIs, RoboBrowser can help.
     from robobrowser import RoboBrowser
 
     # Browse to Genius
-    browser = RoboBrowser(history=True)
+    browser = RoboBrowser(history=True, parser='html.parser')
     browser.open('http://genius.com/')
 
     # Search for Porcupine Tree


### PR DESCRIPTION
Change line 25 to `browser = RoboBrowser(history=True, parser='html.parser')` to avoid `No parser was explicitly specified, so I'm using the best available HTML parser for this system` error from Beautiful Soup.