### PR TITLE
Added check for separated options with identical name

### DIFF
--- a/robobrowser/forms/form.py
+++ b/robobrowser/forms/form.py
@@ -186,7 +186,7 @@ class Form(object):
         if not isinstance(field, fields.BaseField):
             raise ValueError('Argument "field" must be an instance of '
                              'BaseField')
-        if field.name in self.fields:
+        if (isinstance(field, fields.Checkbox) or isinstance(field, fields.Radio)) and field.name in self.fields:
             self.fields[field.name].options.extend(field.options)
         else:
             self.fields.add(field.name, field)

--- a/robobrowser/forms/form.py
+++ b/robobrowser/forms/form.py
@@ -102,6 +102,7 @@ class Payload(object):
     `data`.
 
     """
+
     def __init__(self):
         self.data = OrderedMultiDict()
         self.options = collections.defaultdict(OrderedMultiDict)
@@ -185,7 +186,10 @@ class Form(object):
         if not isinstance(field, fields.BaseField):
             raise ValueError('Argument "field" must be an instance of '
                              'BaseField')
-        self.fields.add(field.name, field)
+        if field.name in self.fields:
+            self.fields[field.name].options.extend(field.options)
+        else:
+            self.fields.add(field.name, field)
 
     @property
     def submit_fields(self):
@@ -223,5 +227,6 @@ class Form(object):
         :return: Payload instance
 
         """
-        include_fields = prepare_fields(self.fields, self.submit_fields, submit)
+        include_fields = prepare_fields(
+            self.fields, self.submit_fields, submit)
         return Payload.from_fields(include_fields)

--- a/robobrowser/forms/form.py
+++ b/robobrowser/forms/form.py
@@ -186,7 +186,8 @@ class Form(object):
         if not isinstance(field, fields.BaseField):
             raise ValueError('Argument "field" must be an instance of '
                              'BaseField')
-        if (isinstance(field, fields.Checkbox) or isinstance(field, fields.Radio)) and field.name in self.fields:
+        if (isinstance(field, fields.Checkbox) or isinstance(field, fields.Radio)) \
+                and field.name in self.fields:
             self.fields[field.name].options.extend(field.options)
         else:
             self.fields.add(field.name, field)


### PR DESCRIPTION
This re-groups checkboxes/options if they are separated in a form but belong together by name. Addresses #65