### PR TITLE
Add support for the HTML image input tag

### DIFF
--- a/robobrowser/forms/fields.py
+++ b/robobrowser/forms/fields.py
@@ -57,6 +57,11 @@ class Submit(Input):
     pass
 
 
+class ImageSubmit(Submit):
+    def serialize(self):
+        return {self.name + '.x': '0', self.name + '.y': '0'}
+
+
 class FileInput(BaseField):
 
     @BaseField.value.setter

--- a/robobrowser/forms/form.py
+++ b/robobrowser/forms/form.py
@@ -44,6 +44,8 @@ def _parse_field(tag, tags):
         tag_type = tag.get('type', '').lower()
         if tag_type == 'submit':
             return fields.Submit(tag)
+        if tag_type == 'image':
+            return fields.ImageSubmit(tag)
         if tag_type == 'file':
             return fields.FileInput(tag)
         if tag_type == 'radio':

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -253,6 +253,14 @@ class TestParser(unittest.TestCase):
         assert_equal(len(_fields), 1)
         assert_true(isinstance(_fields[0], fields.MultiSelect))
 
+    def test_parse_image_submit(self):
+        html = '''
+            <input type="image" name="image_submit" />
+        '''
+        _fields = _parse_fields(BeautifulSoup(html))
+        assert_equal(len(_fields), 1)
+        assert_true(isinstance(_fields[0], fields.ImageSubmit))
+
 
 class TestInput(unittest.TestCase):
 
@@ -613,6 +621,23 @@ class TestFileInput(unittest.TestCase):
         assert_equal(
             self.input.serialize(),
             {'song': file}
+        )
+
+
+
+class TestImageSubmit(unittest.TestCase):
+
+    def setUp(self):
+        self.html = '<input type="image" name="image_submit">'
+        self.input = fields.ImageSubmit(BeautifulSoup(self.html).find('input'))
+
+    def test_name(self):
+        assert_equal(self.input.name, 'image_submit')
+
+    def test_serialize(self):
+        assert_equal(
+            self.input.serialize(),
+            {'image_submit.x': '0', 'image_submit.y': '0'}
         )
 
 


### PR DESCRIPTION
The [`<input type="image" />` tag](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/image) was not yet supported. 

I've ignored nameless elements for now (technically it is permitted to omit the `name` attribute, at which point only `x` and `y` values are submitted).