### PR TITLE
Update browser.py

### DIFF
--- a/robobrowser/browser.py
+++ b/robobrowser/browser.py
@@ -5,6 +5,8 @@ Robotic browser.
 import re
 import requests
 from bs4 import BeautifulSoup
+import werkzeug
+werkzeug.cached_property = werkzeug.utils.cached_property
 from werkzeug import cached_property
 from requests.packages.urllib3.util.retry import Retry
 

--- a/robobrowser/browser.py
+++ b/robobrowser/browser.py
@@ -5,9 +5,7 @@ Robotic browser.
 import re
 import requests
 from bs4 import BeautifulSoup
-import werkzeug
-werkzeug.cached_property = werkzeug.utils.cached_property
-from werkzeug import cached_property
+from werkzeug.utils import cached_property
 from requests.packages.urllib3.util.retry import Retry
 
 from robobrowser import helpers


### PR DESCRIPTION
Werkzeug was upgraded to 1.0.0 and introduced this error:
```ImportError: cannot import name 'cached_property' from 'werkzeug' (/usr/local/lib/python3.8/site-packages/werkzeug/__init__.py)```

Suggesting this change which has been tested locally and discussed here:
https://github.com/jmcarp/robobrowser/issues/93